### PR TITLE
docs: 門番が拾った公開層の 3 件を直す

### DIFF
--- a/WRITING.md
+++ b/WRITING.md
@@ -47,7 +47,7 @@
 
 ## private 起源のとき（README 第3条の実務）
 
-playground など private repo 由来のものは、**指す先が無い**。だから:
+private repo 由来のものは、**指す先が無い**。だから:
 
 - 出自を名乗らない。private repo 名を書かない。
 - **解決できない参照を置かない**（commit hash・内部 path・「詳細は社内 doc」）。

--- a/results/ai-pixel-art-structural-precision-2026-03-25.md
+++ b/results/ai-pixel-art-structural-precision-2026-03-25.md
@@ -1,7 +1,6 @@
 # AI がドット絵を描くとき何が難しいか — 構造的精度保証の試み
 
 > 2026-03-25 / Eris @ Three Hearts Space
-> 関連: [eris-ths/eris-desktop](https://github.com/eris-ths/eris-desktop)
 
 ---
 

--- a/results/th-loop-v2-architecture-2026-01-31.md
+++ b/results/th-loop-v2-architecture-2026-01-31.md
@@ -89,7 +89,7 @@ last_read_timestamp の仕組み:
 }
 ```
 
-Stop と SubagentStop の両方をフック。しもべ（サブエージェント）が終了しようとしても、ループが active なら継続させる。
+Stop と SubagentStop の両方をフック。サブエージェントが終了しようとしても、ループが active なら継続させる。
 
 ---
 


### PR DESCRIPTION
漏洩門番（private 実験側の監査スクリプト）を**この公開 repo に向けて**回したところ、#88 で立てたばかりの規約に反する箇所が 3 件出た。規約を書いた本人が破っていたので直す。

- **`WRITING.md`** — 本文に private リポジトリ名を書いていた。「private repo 名を書かない」と規定している当の文書で。一般化して除去。
- **`results/ai-pixel-art-structural-precision-2026-03-25.md`** — 冒頭の関連リンクが**非公開リポジトリ**を指しており、訪問者から見て永久に解決できない参照だった（Boundary 第3条そのものの実例）。行ごと削除。
- **`results/th-loop-v2-architecture-2026-01-31.md`** — 内部語を「サブエージェント」へ言い換え。

これで公開 repo 全体が門番で**緑**。allowlist で明示的に許可したのは、Claude Code の公開仕様として plugin cache path を説明する 1 行のみ。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017fe1cMq6Q9CK9Rb5g5cWUt)_